### PR TITLE
Use a relative reference to the Xcode project

### DIFF
--- a/Rainier.xcworkspace/contents.xcworkspacedata
+++ b/Rainier.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "absolute:/Users/brent/Projects/Rainier/Rainier.xcodeproj">
+      location = "container:Rainier.xcodeproj">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
This changes _Ranier.xcworkspace_'s reference to _Ranier.xcodeproj_ to be relative, rather than absolute. This makes the project build on other machines, or from other directories on the same machine.